### PR TITLE
ステータスコードに応じた中間処理を挟めるようにメソッド追加

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -1,26 +1,48 @@
 package service
 
 import (
+	"bytes"
+	"io"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"net/http/httputil"
+	"strings"
 
 	"github.com/kyu-suke/fuinsareshi/consts"
 )
 
-type insertionFunc map[int]func(response *http.Response) error
+type insertionFuncs map[int]func(response *http.Response) error
 
-var InsertionFunc insertionFunc = map[int]func(response *http.Response) error{}
+var InsertionFuncs insertionFuncs = map[int]func(response *http.Response) error{}
 
 func Proxy() {
 	director := func(request *http.Request) {
 		request.URL.Scheme = consts.Scheme
 		request.URL.Host = consts.Port
 	}
+
+	// TODO ModifyResponseがエラーの場合の挙動調べる
 	modifyResponse := func(response *http.Response) error {
 
-		if f, ok := InsertionFunc[response.StatusCode]; ok {
+		if f, ok := InsertionFuncs[response.StatusCode]; ok {
+			buf := new(bytes.Buffer)
+			reader := io.TeeReader(response.Body, buf)
+			body, err := ioutil.ReadAll(reader)
+			if err != nil {
+				log.Fatal(err.Error())
+			}
+			response.Body = ioutil.NopCloser(buf)
+
 			f(response)
+
+			afterBody, err := ioutil.ReadAll(response.Body)
+			if err != nil {
+				log.Fatal(err.Error())
+			}
+			if len(afterBody) == 0 {
+				response.Body = ioutil.NopCloser(strings.NewReader(string(body)))
+			}
 		}
 
 		return nil
@@ -39,13 +61,13 @@ func Proxy() {
 }
 
 func addMethod(i int, f func(response *http.Response) error) {
-	InsertionFunc[i] = f
+	InsertionFuncs[i] = f
 }
 
-func (insertionFunc) Statusok(f func(response *http.Response) error) {
+func (insertionFuncs) Statusok(f func(response *http.Response) error) {
 	addMethod(http.StatusOK, f)
 }
 
-func (insertionFunc) StatusNotFound(f func(response *http.Response) error) {
+func (insertionFuncs) StatusNotFound(f func(response *http.Response) error) {
 	addMethod(http.StatusNotFound, f)
 }

--- a/service/service.go
+++ b/service/service.go
@@ -8,14 +8,26 @@ import (
 	"github.com/kyu-suke/fuinsareshi/consts"
 )
 
-func Proxy() {
+type insertionFunc map[int]func(response *http.Response) error
 
+var InsertionFunc insertionFunc = map[int]func(response *http.Response) error{}
+
+func Proxy() {
 	director := func(request *http.Request) {
 		request.URL.Scheme = consts.Scheme
 		request.URL.Host = consts.Port
 	}
+	modifyResponse := func(response *http.Response) error {
+
+		if f, ok := InsertionFunc[response.StatusCode]; ok {
+			f(response)
+		}
+
+		return nil
+	}
 	rp := &httputil.ReverseProxy{
-		Director: director,
+		Director:       director,
+		ModifyResponse: modifyResponse,
 	}
 	server := http.Server{
 		Addr:    consts.ProxyPort,
@@ -24,5 +36,16 @@ func Proxy() {
 	if err := server.ListenAndServe(); err != nil {
 		log.Fatal(err.Error())
 	}
+}
 
+func addMethod(i int, f func(response *http.Response) error) {
+	InsertionFunc[i] = f
+}
+
+func (insertionFunc) Statusok(f func(response *http.Response) error) {
+	addMethod(http.StatusOK, f)
+}
+
+func (insertionFunc) StatusNotFound(f func(response *http.Response) error) {
+	addMethod(http.StatusNotFound, f)
 }

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -1,8 +1,6 @@
 package service
 
 import (
-	"bytes"
-	"io"
 	"io/ioutil"
 	"testing"
 
@@ -51,11 +49,8 @@ func handler(w http.ResponseWriter, r *http.Request) {
 
 func Test中間処理加えるテスト(t *testing.T) {
 	funcBody := ""
-	InsertionFunc.Statusok(func(r *http.Response) error {
-		buf := new(bytes.Buffer)
-		reader := io.TeeReader(r.Body, buf)
-		r.Body = ioutil.NopCloser(buf)
-		body, err := ioutil.ReadAll(reader)
+	InsertionFuncs.Statusok(func(r *http.Response) error {
+		body, err := ioutil.ReadAll(r.Body)
 		if err != nil {
 			t.Fatal("エラーです")
 		}
@@ -77,11 +72,8 @@ func Test中間処理加えるテスト(t *testing.T) {
 		t.Fatal("結果がおかしいです")
 	}
 
-	InsertionFunc.StatusNotFound(func(r *http.Response) error {
-		buf := new(bytes.Buffer)
-		reader := io.TeeReader(r.Body, buf)
-		r.Body = ioutil.NopCloser(buf)
-		body, err := ioutil.ReadAll(reader)
+	InsertionFuncs.StatusNotFound(func(r *http.Response) error {
+		body, err := ioutil.ReadAll(r.Body)
 		if err != nil {
 			t.Fatal("エラーです")
 		}

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"bytes"
+	"io"
 	"io/ioutil"
 	"testing"
 
@@ -15,11 +17,11 @@ func TestProxy(t *testing.T) {
 
 	go Proxy()
 
-	http.HandleFunc("/", handler)
+	http.HandleFunc("/index", handler)
 	go http.ListenAndServe(consts.Port, nil)
 
 	c := http.Client{}
-	resp, err := c.Get("http://localhost:8080")
+	resp, err := c.Get("http://localhost:8080/index")
 	if err != nil {
 		t.Fatal("url変です")
 	}
@@ -29,7 +31,7 @@ func TestProxy(t *testing.T) {
 	}
 
 	proxyClient := http.Client{}
-	proxyResp, err := proxyClient.Get("http://localhost:9000")
+	proxyResp, err := proxyClient.Get("http://localhost:9000/index")
 	if err != nil {
 		t.Fatal("url変です")
 	}
@@ -45,4 +47,59 @@ func TestProxy(t *testing.T) {
 
 func handler(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "Hello, World")
+}
+
+func Test中間処理加えるテスト(t *testing.T) {
+	funcBody := ""
+	InsertionFunc.Statusok(func(r *http.Response) error {
+		buf := new(bytes.Buffer)
+		reader := io.TeeReader(r.Body, buf)
+		r.Body = ioutil.NopCloser(buf)
+		body, err := ioutil.ReadAll(reader)
+		if err != nil {
+			t.Fatal("エラーです")
+		}
+		funcBody = string(body)
+		return nil
+	})
+
+	proxyClient := http.Client{}
+	proxyResp, err := proxyClient.Get("http://localhost:9000/index")
+	if err != nil {
+		t.Fatal("url変です")
+	}
+	proxyResult, err := ioutil.ReadAll(proxyResp.Body)
+	if err != nil {
+		t.Fatal("レスポンス変です")
+	}
+
+	if funcBody != string(proxyResult) {
+		t.Fatal("結果がおかしいです")
+	}
+
+	InsertionFunc.StatusNotFound(func(r *http.Response) error {
+		buf := new(bytes.Buffer)
+		reader := io.TeeReader(r.Body, buf)
+		r.Body = ioutil.NopCloser(buf)
+		body, err := ioutil.ReadAll(reader)
+		if err != nil {
+			t.Fatal("エラーです")
+		}
+		funcBody = string(body)
+		return nil
+	})
+
+	notFoundProxyClient := http.Client{}
+	notFoundProxyResp, err := notFoundProxyClient.Get("http://localhost:9000/notfoud")
+	if err != nil {
+		t.Fatal("url変です")
+	}
+	notFoundProxyResult, err := ioutil.ReadAll(notFoundProxyResp.Body)
+	if err != nil {
+		t.Fatal("レスポンス変です")
+	}
+
+	if funcBody != string(notFoundProxyResult) {
+		t.Fatal("結果がおかしいです")
+	}
 }


### PR DESCRIPTION
@sgswtky 

# 概要
レスポンスのステータスコード毎に別途処理を挟みたい場合がある
なので `httputil.ReverseProxy` の `ModifyResponse` を利用してステータスコード毎に実行するメソッドを定義できるようにした

# やったこと
- ステータスコード毎に定義するメソッドを用意 (200, 404を用意した)
- 404がほしかったのでテストコードに `/index` を追加

# レビュー
- テストコード大丈夫?
- `insertionFunc` とか関数の持ち方とか他にいい方法ある？
